### PR TITLE
Fix for Gradle 8.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,6 +26,8 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
+
+    gabrimatic.info.restart
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
 
-    gabrimatic.info.restart
+    namespace "gabrimatic.info.restart"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
Hello,

I realised, that restart_app 1.2.1 is not compatible with Gradle 8.x so I fixed it. It was just a smaller problem. I needed to add the namespace from the android Manifest to the build.gradle. Must work with lower Gradle versions too

Have a nice day :)